### PR TITLE
feat: Implement update_sitemap function

### DIFF
--- a/canonicalwebteam/directory_parser/__init__.py
+++ b/canonicalwebteam/directory_parser/__init__.py
@@ -1,4 +1,5 @@
 from canonicalwebteam.directory_parser.app import (  # noqa
     scan_directory,  # noqa
     generate_sitemap,  # noqa
+    update_sitemap,  # noqa
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.1.1",
+    version="1.1.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- Implement `update_sitemap` function that parses the existing sitemap tree and modifies it according to GH triggered actions: "ADD", "UPDATE" or "DELETE"
- The function is called and imported in the `sitemap.py` file [here](https://github.com/canonical/ubuntu.com/pull/14900/files). Once this PR is merged, the function will be called on GH actions and update sitemaps accordingly

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes [WD-17182](https://warthogs.atlassian.net/browse/WD-17182)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17182]: https://warthogs.atlassian.net/browse/WD-17182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ