### PR TITLE
feat: Include markdown files as valid templates

### DIFF
--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -14,7 +14,7 @@ BASE_TEMPLATES = [
 ]
 MARKDOWN_TEMPLATES = [
     "legal/_base_legal_markdown.html",
-    "appliance/shared/_base_appliance_index.html"
+    "appliance/shared/_base_appliance_index.html",
 ]
 TEMPLATE_PREFIXES = ["base", "_base"]
 TAG_MAPPING = {
@@ -230,7 +230,9 @@ def is_valid_page(path, extended_path, is_index=True):
     if "index.md" in str(path):
         with path.open("r") as f:
             for line in f.readlines():
-                if match := re.search(r"wrapper_template:\s*[\"']?(.*?)[\"']?$", line):
+                if match := re.search(
+                    r"wrapper_template:\s*[\"']?(.*?)[\"']?$", line
+                ):
                     template = match.group(1)
                     if template in MARKDOWN_TEMPLATES:
                         return True
@@ -321,7 +323,7 @@ def scan_directory(path_name, base=None):
 
     is_index_page_valid = False
 
-    # Check if an index.html file exists in this directory
+    # Check if an index.html or index.md file exists in this directory
     (has_index, index_type) = check_has_index(node_path)
     if has_index:
         index_path = node_path / ("index." + index_type)

--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -12,6 +12,10 @@ BASE_TEMPLATES = [
     "templates/one-column.html",
     "_base/base.html",
 ]
+MARKDOWN_TEMPLATES = [
+    "legal/_base_legal_markdown.html",
+    "appliance/shared/_base_appliance_index.html"
+]
 TEMPLATE_PREFIXES = ["base", "_base"]
 TAG_MAPPING = {
     "title": ["title"],
@@ -21,11 +25,16 @@ TAG_MAPPING = {
 
 
 def is_index(path):
-    return path.name == "index.html"
+    return path.name == "index.html" or path.name == "index.md"
 
 
 def check_has_index(path):
-    return (path / "index.html").exists()
+    if (path / "index.html").exists():
+        return True, "html"
+    elif (path / "index.md").exists():
+        return True, "md"
+    else:
+        return False, None
 
 
 def is_template(path):
@@ -195,7 +204,7 @@ def get_tags_rolling_buffer(path):
                     break
 
     # We add the name from the path
-    raw_name = re.sub(r"(?i)(.html|/index.html)", "", str(path))
+    raw_name = re.sub(r"(?i)(.html|/index.html|/index.md)", "", str(path))
     tags["name"] = raw_name.split("/templates", 1)[-1]
 
     return tags
@@ -206,6 +215,7 @@ def is_valid_page(path, extended_path, is_index=True):
     Determine if path is a valid page. Pages are valid if:
     - They contain the same extended path as the index html.
     - They extend from the base html.
+    - They are markdown files with a valid wrapper template
     """
     if is_template(path):
         return False
@@ -216,6 +226,15 @@ def is_valid_page(path, extended_path, is_index=True):
                 if match := re.search("{% extends [\"'](.*?)[\"'] %}", line):
                     if match.group(1) == extended_path:
                         return True
+
+    if "index.md" in str(path):
+        with path.open("r") as f:
+            for line in f.readlines():
+                if match := re.search(r"wrapper_template:\s*[\"']?(.*?)[\"']?$", line):
+                    template = match.group(1)
+                    if template in MARKDOWN_TEMPLATES:
+                        return True
+
     # If the file does not share the extended path, check if it extends the
     # base html
     return extends_base(path)
@@ -226,8 +245,9 @@ def get_extended_path(path):
     with path.open("r") as f:
         for line in f.readlines():
             # TODO: also match single quotes \'
-            if match := re.search("{% extends [\"'](.*?)[\"'] %}", line):
-                return match.group(1)
+            if ".html" in str(path):
+                if match := re.search("{% extends [\"'](.*?)[\"'] %}", line):
+                    return match.group(1)
 
 
 def update_tags(tags, new_tags):
@@ -302,9 +322,9 @@ def scan_directory(path_name, base=None):
     is_index_page_valid = False
 
     # Check if an index.html file exists in this directory
-    has_index = check_has_index(node_path)
+    (has_index, index_type) = check_has_index(node_path)
     if has_index:
-        index_path = node_path / "index.html"
+        index_path = node_path / ("index." + index_type)
         # Get the path extended by the index.html file
         extended_path = get_extended_path(index_path)
         # If the file is valid, add it as a child

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.1.2",
+    version="1.1.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- Include template paths with `index.md` as valid templates
- Include lastmod values from markdown files in sitemap parser
- Note: Some files are not being parsed as valid files and will be addressed in a separate ticket. The scope of this ticket is to include previously missing `lastmod` values for template without "index.html"

## QA

- Go to https://ubuntu-com-14938.demos.haus/sitemap_parser
- Do a search on markdown files such as: `legal/`, `appliance/`
- See that the files are present on the parser and returns a valid lastmod date

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes [WD-20086](https://warthogs.atlassian.net/browse/WD-20086)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20086]: https://warthogs.atlassian.net/browse/WD-20086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ