### PR TITLE
feat: Prevent unexpected pages from being parsed

### DIFF
--- a/canonicalwebteam/directory_parser/__init__.py
+++ b/canonicalwebteam/directory_parser/__init__.py
@@ -1,5 +1,4 @@
 from canonicalwebteam.directory_parser.app import (  # noqa
     scan_directory,  # noqa
     generate_sitemap,  # noqa
-    update_sitemap,  # noqa
 )

--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -206,9 +206,19 @@ def is_valid_page(path, extended_path, is_index=True):
     Determine if path is a valid page. Pages are valid if:
     - They contain the same extended path as the index html.
     - They extend from the base html.
+    - Does not have "noindex" in the meta tags.
+    - Does not live in a shared template directory.
     """
     if is_template(path):
         return False
+
+    with path.open("r") as f:
+        for line in f.readlines():
+            if re.search(
+                r'<meta\s+name=["\']robots["\']\s+content=["\'].*?noindex.*?["\']',
+                line
+            ):
+                return False
 
     if not is_index and extended_path:
         with path.open("r") as f:

--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -215,7 +215,7 @@ def is_valid_page(path, extended_path, is_index=True):
         for line in f.readlines():
             if re.search(
                 r'<meta\s+name=["\']robots["\']\s+content=["\'].*?noindex.*?["\']',
-                line
+                line,
             ):
                 return False
 
@@ -307,9 +307,7 @@ def scan_directory(path_name, exclude_paths=None, base=None):
         # Get the path extended by the index.html file
         extended_path = get_extended_path(index_path)
         # If the file is valid, add it as a child
-        is_index_page_valid = is_valid_page(
-            index_path, extended_path
-        )
+        is_index_page_valid = is_valid_page(index_path, extended_path)
         if is_index_page_valid:
             # Get tags, add as child
             tags = get_tags_rolling_buffer(index_path)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.1.2",
+    version="1.1.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- Prevent parsing unexpected pages:
  - Pages with `noindex` metatag
  - Dynamic pages ([see sitemap file](https://ubuntu.com/sitemap.xml))
  - Shared templates
- Fly-by work: Remove deprecated `update_sitemap` function

## QA

- QA steps are in this separate PR https://github.com/canonical/ubuntu.com/pull/14947

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes [WD-20087](https://warthogs.atlassian.net/browse/WD-20087)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20087]: https://warthogs.atlassian.net/browse/WD-20087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ