### PR TITLE
fix: Update build-and-publish pypi action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,15 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        pip3 install --upgrade setuptools pip
+        sudo apt update && sudo apt install -y --no-install-recommends python3-setuptools
+        pip3 install --upgrade setuptools
         pip3 install wheel
 
     - name: Build package
       run: python3 setup.py sdist bdist_wheel
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## Done

- Fix failing `build-and-publish` action

## QA

- This PR is only triggered on push to main, and there is no update to `setup.py` as there are no changes
- Only a code review is required
- Brought over from https://github.com/canonical/canonicalwebteam.form-generator/blob/main/.github/workflows/publish.yml

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes [WD-21248](https://warthogs.atlassian.net/browse/WD-21248)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21248]: https://warthogs.atlassian.net/browse/WD-21248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ