### PR TITLE
feat: Exclude error pages from being parsed

### DIFF
--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -21,6 +21,12 @@ TAG_MAPPING = {
     "description": ["meta_description", "description"],
     "link": ["meta_copydoc"],
 }
+ERROR_PAGES = [
+    "404.html",
+    "401.html",
+    "500.html",
+    "502.html",
+]
 
 
 def is_index(path):
@@ -216,8 +222,8 @@ def is_valid_page(path, extended_path, is_index=True):
     - They extend from the base html.
     - Does not have "noindex" in the meta tags.
     - Does not live in a shared template directory.
-    - They are markdown files with a valid wrapper template
-
+    - They are markdown files with a valid wrapper template.
+    - They are not error pages.
     """
     if is_template(path):
         return False
@@ -231,6 +237,10 @@ def is_valid_page(path, extended_path, is_index=True):
                 line,
             ):
                 return False
+
+    end_path = str(path).split("/")[-1]
+    if end_path in ERROR_PAGES:
+        return False
 
     if not is_index and extended_path:
         with path.open("r") as f:

--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -22,7 +22,11 @@ TAG_MAPPING = {
     "link": ["meta_copydoc"],
 }
 ERROR_PAGES = [
+    "400.html",
+    "403.html",
     "404.html",
+    "410.html",
+    "429.html",
     "401.html",
     "500.html",
     "502.html",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.2.7",
+    version="1.2.8",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- Prevent error templates from being parsed
- Added a list of error pages from u.com and c.com

## QA
- Go to https://canonical-com-1645.demos.haus/sitemap_tree.xml
- See that error paths such as /404, /401, /500 are excluded in the sitemap

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes #



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
