### PR TITLE
fix: Exclude non-indexed pages on sitemap templates

### DIFF
--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -336,7 +336,6 @@ def scan_directory(path_name, exclude_paths=None, base=None):
 
     # This will be the base html file extended by the index.html
     extended_path = None
-
     is_index_page_valid = False
 
     # Check if an index.html or index.md file exists in this directory
@@ -355,6 +354,8 @@ def scan_directory(path_name, exclude_paths=None, base=None):
             lastmod_time = get_git_last_modified_time(index_path)
             if lastmod_time:
                 node["last_modified"] = lastmod_time
+    else:
+        node["sitemap_exclude"] = True
 
     # Cycle through other files in this directory
     for child in node_path.iterdir():

--- a/canonicalwebteam/directory_parser/templates/sitemap_children.xml
+++ b/canonicalwebteam/directory_parser/templates/sitemap_children.xml
@@ -1,10 +1,8 @@
 
-<url>
-  {% if not node["sitemap_exclude"] %}
+{% if not node["sitemap_exclude"] %}<url>
   <loc>{{ base_url }}{{ node["name"] }}</loc>
   {% if node["last_modified"] != None %}<lastmod>{{ node["last_modified"] }}</lastmod>{% endif %}
-  {% endif %}
-</url>
+</url>{% endif %}
 {%- if node["children"]|length > 0 -%}
   {%- for node in node["children"] %}
     {%- include "sitemap_children.xml" %}

--- a/canonicalwebteam/directory_parser/templates/sitemap_children.xml
+++ b/canonicalwebteam/directory_parser/templates/sitemap_children.xml
@@ -1,7 +1,9 @@
 
 <url>
+  {% if not node["sitemap_exclude"] %}
   <loc>{{ base_url }}{{ node["name"] }}</loc>
   {% if node["last_modified"] != None %}<lastmod>{{ node["last_modified"] }}</lastmod>{% endif %}
+  {% endif %}
 </url>
 {%- if node["children"]|length > 0 -%}
   {%- for node in node["children"] %}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.2.8",
+    version="1.2.9",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- Exclude directories without `index.html` or `index.md` from being added to the parser
- The directory should not be removed from the tree parser as they have valid children pages

## QA

- Go to https://canonical-com-1645.demos.haus/sitemap_parser
- See that /solutions `sitemap_exclude` is set to True
- Go to https://canonical-com-1645.demos.haus/sitemap_tree.xml
- See that /solutions is not present in sitemap

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes #



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
