### PR TITLE
fix: Include homepage in sitemap template

### DIFF
--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -394,7 +394,7 @@ def generate_sitemap(directory_path, base_url, exclude_paths=None):
     tree = scan_directory(directory_path, exclude_paths)
     xml_sitemap = flask.render_template(
         "sitemap_template.xml",
-        tree=tree["children"],
+        tree=tree,
         base_url=base_url,
     )
     return xml_sitemap

--- a/canonicalwebteam/directory_parser/templates/sitemap_template.xml
+++ b/canonicalwebteam/directory_parser/templates/sitemap_template.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">  
-  {%- for node in tree %}
-  {%- include "sitemap_children.xml" %}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {% if not tree["sitemap_exclude"] %}<url>
+    <loc>{{ base_url }}{{ tree["name"] }}</loc>
+    {% if tree["last_modified"] != None %}<lastmod>{{ tree["last_modified"] }}</lastmod>{% endif %}
+  </url>{% endif %}
+  {%- for node in tree["children"] %}
+    {%- include "sitemap_children.xml" %}
   {%- endfor %}
 </urlset>

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.2.9",
+    version="1.2.10",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- Update `sitemap_template.xml` to include homepage

## QA

- Go to https://canonical-com-1654.demos.haus/sitemap_tree.xml
- See that homepage is indexed

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.directory-parser/releases/latest)


## Issue / Card

Fixes #



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
