### PR TITLE
fix: exclude underscore-prefixed partials from sitemap

### DIFF
--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -48,12 +48,18 @@ def check_has_index(path):
 
 def is_template(path):
     """
-    Return True if the file name starts with a template prefix.
+    Return True if the file/directory is a template rather than a page.
+
+    By convention, names starting with an underscore (e.g. _tutorial.html,
+    _thank-you.html) are partials or wrapper templates, not standalone pages,
+    so they are excluded from the sitemap.
 
     TODO: It is possible that valid page uris start with one of these prefixes.
     Instead, we could match the extended_path in index.html to files in the
     folder, and exclude files whose filename is in the extended path.
     """
+    if path.name.startswith("_"):
+        return True
     for prefix in TEMPLATE_PREFIXES:
         if path.name.startswith(prefix):
             return True

--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -345,7 +345,7 @@ def scan_directory(path_name, exclude_paths=None, base=None):
     is_index_page_valid = False
 
     # Check if an index.html or index.md file exists in this directory
-    (has_index, index_type) = check_has_index(node_path)
+    has_index, index_type = check_has_index(node_path)
     if has_index:
         index_path = node_path / ("index." + index_type)
         # Get the path extended by the index.html file

--- a/canonicalwebteam/directory_parser/app.py
+++ b/canonicalwebteam/directory_parser/app.py
@@ -48,22 +48,27 @@ def check_has_index(path):
 
 def is_template(path):
     """
-    Return True if the file/directory is a template rather than a page.
-
-    By convention, names starting with an underscore (e.g. _tutorial.html,
-    _thank-you.html) are partials or wrapper templates, not standalone pages,
-    so they are excluded from the sitemap.
+    Return True if the file name starts with a base-template prefix.
 
     TODO: It is possible that valid page uris start with one of these prefixes.
     Instead, we could match the extended_path in index.html to files in the
     folder, and exclude files whose filename is in the extended path.
     """
-    if path.name.startswith("_"):
-        return True
     for prefix in TEMPLATE_PREFIXES:
         if path.name.startswith(prefix):
             return True
     return False
+
+
+def is_partial(path):
+    """
+    Return True if the file is a partial rather than a standalone page.
+
+    By convention, names starting with an underscore (e.g. _tutorial.html,
+    _thank-you.html) are partials or wrapper templates, not standalone pages,
+    so they are excluded from the sitemap.
+    """
+    return path.name.startswith("_")
 
 
 def append_base_path(base, path_name):
@@ -235,7 +240,7 @@ def is_valid_page(path, extended_path, is_index=True):
     - They are markdown files with a valid wrapper template.
     - They are not error pages.
     """
-    if is_template(path):
+    if is_template(path) or is_partial(path):
         return False
 
     with path.open("r") as f:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.directory-parser",
-    version="1.2.10",
+    version="1.2.11",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.directory-parser",


### PR DESCRIPTION
## Done

- `is_template()` now treats any file/directory whose name starts with an underscore as a template (partial/wrapper), so it is excluded from the generated sitemap.
- **Why:** By convention, underscore-prefixed templates (e.g. `_tutorial.html`, `_thank-you.html`) are partials or wrapper templates, not standalone pages. Previously `is_template()` only matched the `base`/`_base` prefixes, so these partials passed `is_valid_page()` (they `{% extends %}` a base template) and leaked into the sitemap as `<loc>` entries like `https://canonical.com/maas/_tutorial` and `https://canonical.com/tests/_thank-you`. The existing `exclude_paths`/`DYNAMIC_SITEMAPS` regex mechanism can't catch these because it only filters *directory* nodes, not individual files.
- Bumped package version `1.2.10` → `1.2.11`.

## QA

- [x] Check that https://canonical-com-2575.demos.haus/sitemap_tree.xml has no lines starting with `_` like `https://canonical.com/maas/_tutorial` and compare that with https://canonical.com/sitemap_tree.xml.
- [x] Confirm the `_`-prefixed file is **absent** from the sitemap and the normal page is still present.

### Check if PR is ready for release

- [x] Package version in `setup.py` should be updated relative to the most recent release

## Issue / Card
https://warthogs.atlassian.net/browse/WD-37042
N/A — reported via canonical.com sitemap containing `<loc>` entries for `/maas/_tutorial` and `/tests/_thank-you`.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)